### PR TITLE
[Fix] Close VFS file manager by default

### DIFF
--- a/vfs/src/main/scala/VFSTransport.scala
+++ b/vfs/src/main/scala/VFSTransport.scala
@@ -97,7 +97,7 @@ object VFSTransport {
 
         mngr.setBaseFile(mngr.resolveFile(uri))
 
-        Try(VFSTransport(mngr))
+        Try(new VFSTransport(mngr, () => mngr.close()))
       }
     }
 


### PR DESCRIPTION
Default initialisation creates a file manager that load resources
that may leak such as org.apache.commons.vfs2.cache.SoftRefFilesCache

# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](../CONTRIBUTING.md)?

## Purpose

This PR close the VFS file manager created by default using the `VFSFactory`. This file manager instanciate by default a cache system that is never stopped.
