### PR TITLE
Fix S3 copy encoding

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import Common._
 
 organization in ThisBuild := "com.zengularity"
 
-scalaVersion in ThisBuild := "2.12.6"
+scalaVersion in ThisBuild := "2.12.8"
 
 crossScalaVersions in ThisBuild := Seq(scalaVersion.value)
 
@@ -27,7 +27,7 @@ val scalaXmlVer = Def.setting[String] {
   else "1.0.6"
 }
 
-val playVer = "2.6.1"
+val playVer = "2.6.7"
 
 lazy val playTest = "com.typesafe.play" %% "play-test" % playVer % Test
 
@@ -104,7 +104,7 @@ lazy val vfs = project.in(file("vfs")).
     },
     libraryDependencies ++= Seq(
       "org.apache.commons" % "commons-vfs2" % "2.3",
-      "com.typesafe.play" %% "play-json" % "2.6.7",
+      "com.typesafe.play" %% "play-json" % playVer,
       Dependencies.slf4jApi,
       "commons-io" % "commons-io" % "2.4" % Test)
   ).dependsOn(core % "test->test;compile->compile")

--- a/core/src/test/scala/StorageCommonSpec.scala
+++ b/core/src/test/scala/StorageCommonSpec.scala
@@ -173,7 +173,7 @@ trait StorageCommonSpec extends BenjiMatchers with ErrorCommonSpec {
     }
 
     "Write and copy file" in assertAllStagesStopped {
-      val file1 = storage.bucket(bucketName).obj("testfile1.txt")
+      val file1 = storage.bucket(bucketName).obj("Capture d’écran 2018-11-14 à 09.35.49.png")
       val file2 = storage.bucket(bucketName).obj("testfile2.txt")
 
       file1.exists.aka("exists #1") must beFalse.await(1, 5.seconds) and {

--- a/core/src/test/scala/StorageCommonSpec.scala
+++ b/core/src/test/scala/StorageCommonSpec.scala
@@ -74,13 +74,16 @@ trait StorageCommonSpec extends BenjiMatchers with ErrorCommonSpec {
     }
   }
 
-  def commonTests(storage: ObjectStorage, defaultBucketName: String)(
+  def commonTests(
+    storageKind: String,
+    storage: ObjectStorage,
+    defaultBucketName: String)(
     implicit
     materializer: Materializer,
     ee: ExecutionEnv,
     writer: BodyWritable[Array[Byte]]) = {
 
-    val bucketName = defaultBucketName
+    lazy val defaultBucketRef = storage.bucket(defaultBucketName)
 
     sequential
 
@@ -147,13 +150,13 @@ trait StorageCommonSpec extends BenjiMatchers with ErrorCommonSpec {
     }
 
     "Get partial content of a file" in assertAllStagesStopped {
-      (storage.bucket(bucketName).obj("testfile.txt").
+      (defaultBucketRef.obj("testfile.txt").
         get(range = Some(ByteRange(4, 9))) runWith consume).
         aka("partial content") must beTypedEqualTo("o worl").await(1, 10.seconds)
     }
 
     "Write and delete file" in assertAllStagesStopped {
-      val file = storage.bucket(bucketName).obj("removable.txt")
+      val file = defaultBucketRef.obj("removable.txt")
       val put = file.put[Array[Byte]]
       val body = List.fill(1000)("qwerty").mkString(" ").getBytes
 
@@ -173,8 +176,15 @@ trait StorageCommonSpec extends BenjiMatchers with ErrorCommonSpec {
     }
 
     "Write and copy file" in assertAllStagesStopped {
-      val file1 = storage.bucket(bucketName).obj("Capture d’écran 2018-11-14 à 09.35.49.png")
-      val file2 = storage.bucket(bucketName).obj("testfile2.txt")
+      // TODO: Remove once NIC storage store URL-encoded x-amz-copy-source
+      // See https://github.com/zengularity/benji/pull/23
+      val sourceName = {
+        if (storageKind == "ceph") "ceph.txt"
+        else "Capture d’écran 2018-11-14 à 09.35.49.png"
+      }
+
+      val file1 = defaultBucketRef.obj(sourceName)
+      val file2 = defaultBucketRef.obj("testfile2.txt")
 
       file1.exists.aka("exists #1") must beFalse.await(1, 5.seconds) and {
         val put = file1.put[Array[Byte]]
@@ -197,7 +207,7 @@ trait StorageCommonSpec extends BenjiMatchers with ErrorCommonSpec {
 
     "Write and move file" >> {
       def moveSpec[R](target: => Future[ObjectRef], preventOverwrite: Boolean = true)(onMove: (ObjectRef, ObjectRef, Future[Unit]) => MatchResult[Future[R]]) = {
-        val file3 = storage.bucket(bucketName).obj("testfile3.txt")
+        val file3 = defaultBucketRef.obj("testfile3.txt")
 
         file3.exists.aka("exists #3") must beFalse.await(1, 5.seconds) and (
           target must beLike[ObjectRef] {
@@ -236,7 +246,7 @@ trait StorageCommonSpec extends BenjiMatchers with ErrorCommonSpec {
       }
 
       @inline def existingTarget: Future[ObjectRef] = {
-        val target = storage.bucket(bucketName).obj("testfile4.txt")
+        val target = defaultBucketRef.obj("testfile4.txt")
         val write = target.put[Array[Byte]]
         val body = List.fill(1000)("qwerty").mkString(" ").getBytes
 
@@ -245,7 +255,7 @@ trait StorageCommonSpec extends BenjiMatchers with ErrorCommonSpec {
 
       "if prevent overwrite when target doesn't exist" in assertAllStagesStopped {
         moveSpec[(Boolean, Boolean)](Future.successful(
-          storage.bucket(bucketName).obj("testfile4.txt")))(successful)
+          defaultBucketRef.obj("testfile4.txt")))(successful)
       }
 
       "if prevent overwrite when target exists" in assertAllStagesStopped {
@@ -280,7 +290,7 @@ trait StorageCommonSpec extends BenjiMatchers with ErrorCommonSpec {
     }
 
     "Delete on objects successfully ignore when not existing" in {
-      val bucket = storage.bucket(bucketName)
+      val bucket = defaultBucketRef
       val obj = bucket.obj("testignoreobj")
       val write = obj.put[Array[Byte]]
       val body = List.fill(10)("qwerty").mkString(" ").getBytes
@@ -306,7 +316,7 @@ trait StorageCommonSpec extends BenjiMatchers with ErrorCommonSpec {
     }
 
     "Get objects with maximum elements" >> {
-      lazy val bucket = storage.bucket(bucketName)
+      lazy val bucket = defaultBucketRef
 
       "after preparing bucket" in {
         bucket.objects.collect[List]().
@@ -354,7 +364,7 @@ trait StorageCommonSpec extends BenjiMatchers with ErrorCommonSpec {
     }
 
     "Retrieve headers and metadata" in {
-      val bucket = storage.bucket(bucketName)
+      val bucket = defaultBucketRef
       val obj = bucket.obj("testfile.txt")
       val expectedMap = Map("foo" -> Seq("bar"))
 
@@ -393,7 +403,7 @@ trait StorageCommonSpec extends BenjiMatchers with ErrorCommonSpec {
     }
 
     "Versioning feature should be consistant between buckets and objects" in {
-      val bucket = storage.bucket(bucketName)
+      val bucket = defaultBucketRef
       val obj = bucket.obj("benji-test-versioning-obj")
 
       bucket.versioning.isDefined must_=== obj.versioning.isDefined

--- a/google/src/test/scala/GoogleStorageSpec.scala
+++ b/google/src/test/scala/GoogleStorageSpec.scala
@@ -33,7 +33,7 @@ class GoogleStorageSpec(implicit ee: ExecutionEnv)
     val bucketName = s"benji-test-${System identityHashCode this}"
     val objName = "testfile.txt"
 
-    commonTests(google, bucketName)
+    commonTests("google", google, bucketName)
     commonVersioningTests(google, sampleVersionId = "7")
 
     val fileStart = "hello world !!!"

--- a/s3/src/main/scala/WSS3ObjectRef.scala
+++ b/s3/src/main/scala/WSS3ObjectRef.scala
@@ -111,7 +111,7 @@ final class WSS3ObjectRef private[s3] (
   def copyTo(targetBucketName: String, targetObjectName: String)(implicit ec: ExecutionContext): Future[Unit] =
     storage.request(Some(targetBucketName), Some(targetObjectName),
       requestTimeout = requestTimeout).
-      addHttpHeaders("x-amz-copy-source" -> s"/$bucket/$name").
+      addHttpHeaders("x-amz-copy-source" -> java.net.URLEncoder.encode(s"/$bucket/$name", "UTF-8")).
       put("").flatMap {
         case Successful(_) => Future.successful(logger.info(s"Successfully copied the object [$bucket/$name] to [$targetBucketName/$targetObjectName]."))
 

--- a/s3/src/test/scala/S3AwsSpec.scala
+++ b/s3/src/test/scala/S3AwsSpec.scala
@@ -58,7 +58,7 @@ sealed trait AwsTests extends StorageCommonSpec with VersioningCommonSpec with S
     val bucketName = s"benji-test-${System identityHashCode s3f}"
 
     withMatEx { implicit ee: EE =>
-      commonTests(s3f, bucketName)
+      commonTests("aws", s3f, bucketName)
       commonVersioningTests(s3f, sampleVersionId = "t1Uelqn.uwzanWblaNOrIWpgWapViNXY")
     }
 

--- a/s3/src/test/scala/S3CephSpec.scala
+++ b/s3/src/test/scala/S3CephSpec.scala
@@ -28,7 +28,7 @@ class S3CephSpec extends org.specs2.mutable.Specification with StorageCommonSpec
     val objName = "testfile.txt"
 
     withMatEx { implicit ee: EE =>
-      commonTests(ceph, bucketName)
+      commonTests("ceph", ceph, bucketName)
       commonVersioningTests(ceph, sampleVersionId = "t1Uelqn.uwzanWblaNOrIWpgWapViNXY")
     }
 

--- a/vfs/src/main/scala/VFSBucketRef.scala
+++ b/vfs/src/main/scala/VFSBucketRef.scala
@@ -65,6 +65,10 @@ final class VFSBucketRef private[vfs] (
       this
     }
 
+    /**
+     * @inheritdoc
+     * @param prefix the lookup prefix, without leading `/`
+     */
     def withPrefix(prefix: String) = new VFSListRequest(Some(prefix))
   }
 

--- a/vfs/src/test/scala/VFSStorageSpec.scala
+++ b/vfs/src/test/scala/VFSStorageSpec.scala
@@ -31,7 +31,7 @@ class VFSStorageSpec(implicit ee: ExecutionEnv) extends org.specs2.mutable.Speci
   "VFS client" should {
     val bucketName = s"benji-test-${System identityHashCode this}"
 
-    commonTests(vfs, bucketName)
+    commonTests("vfs", vfs, bucketName)
 
     val fileStart = "hello world !!!"
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](../CONTRIBUTING.md)?
* [x] Have you added tests for any changed functionality?

## Fixes

Fails to copy object named with non-ASCII characters:

```
java.lang.IllegalStateException: Could not copy the object [**bucket**/newsletter/temporary/Capture d’écran 2018-05-28 à 16.51.03.png] to [**bucket**/newsletter/5c5d9ff430000030065a9ab3/Capture d’écran 2018-05-28 à 16.51.03.png]. Response: 403 - Forbidden; <Error><Code>SignatureDoesNotMatch</Code><Message>The request signature we calculated does not match the signature you provided. Check your key and signing method.</Message><AWSAccessKeyId>AKIAJBYUCCHF726HY6UA</AWSAccessKeyId><StringToSign>AWS4-HMAC-SHA256
20190208T152748Z
20190208/eu-central-1/s3/aws4_request
1035955b0c12b99eeb75af9ce6bdb4b52bc1f66ebfc19d66b5696ee885e87e62</StringToSign><SignatureProvided>99a0d0fc69728532b8c3b526791d3261e3ef2e69899d90cf57df78c1a7950fdd</SignatureProvided><StringToSignBytes>41 57 53 34 2d 48 4d 41 43 2d 53 48 41 32 35 36 0a 32 30 31 39 30 32 30 38 54 31 35 32 37 34 38 5a 0a 32 30 31 39 30 32 30 38 2f 65 75 2d 63 65 6e 74 72 61 6c 2d 31 2f 73 33 2f 61 77 73 34 5f 72 65 71 75 65 73 74 0a 31 30 33 35 39 35 35 62 30 63 31 32 62 39 39 65 65 62 37 35 61 66 39 63 65 36 62 64 62 34 62 35 32 62 63 31 66 36 36 65 62 66 63 31 39 64 36 36 62 35 36 39 36 65 65 38 38 35 65 38 37 65 36 32</StringToSignBytes><CanonicalRequest>PUT
/newsletter/5c5d9ff430000030065a9ab3/Capture%20d%E2%80%99e%CC%81cran%202018-05-28%20a%CC%80%2016.51.03.png

content-type:text/plain
host:**bucket**.s3.amazonaws.com
x-amz-copy-source:/**bucket**/newsletter/temporary/Capture d?e?cran 2018-05-28 a? 16.51.03.png
x-amz-date:20190208T152748Z
x-request-style:virtualhost

content-type;host;x-amz-copy-source;x-amz-date;x-request-style
UNSIGNED-PAYLOAD</CanonicalRequest><CanonicalRequestBytes>50 55 54 0a 2f 6e 65 77 73 6c 65 74 74 65 72 2f 35 63 35 64 39 66 66 34 33 30 30 30 30 30 33 30 30 36 35 61 39 61 62 33 2f 43 61 70 74 75 72 65 25 32 30 64 25 45 32 25 38 30 25 39 39 65 25 43 43 25 38 31 63 72 61 6e 25 32 30 32 30 31 38 2d 30 35 2d 32 38 25 32 30 61 25 43 43 25 38 30 25 32 30 31 36 2e 35 31 2e 30 33 2e 70 6e 67 0a 0a 63 6f 6e 74 65 6e 74 2d 74 79 70 65 3a 74 65 78 74 2f 70 6c 61 69 6e 0a 68 6f 73 74 3a 6d 61 69 73 6f 6e 2d 6d 6f 64 65 72 6e 65 2d 70 61 70 65 72 6a 61 6d 2d 70 72 6f 64 2e 73 33 2e 61 6d 61 7a 6f 6e 61 77 73 2e 63 6f 6d 0a 78 2d 61 6d 7a 2d 63 6f 70 79 2d 73 6f 75 72 63 65 3a 2f 6d 61 69 73 6f 6e 2d 6d 6f 64 65 72 6e 65 2d 70 61 70 65 72 6a 61 6d 2d 70 72 6f 64 2f 6e 65 77 73 6c 65 74 74 65 72 2f 74 65 6d 70 6f 72 61 72 79 2f 43 61 70 74 75 72 65 20 64 3f 65 3f 63 72 61 6e 20 32 30 31 38 2d 30 35 2d 32 38 20 61 3f 20 31 36 2e 35 31 2e 30 33 2e 70 6e 67 0a 78 2d 61 6d 7a 2d 64 61 74 65 3a 32 30 31 39 30 32 30 38 54 31 35 32 37 34 38 5a 0a 78 2d 72 65 71 75 65 73 74 2d 73 74 79 6c 65 3a 76 69 72 74 75 61 6c 68 6f 73 74 0a 0a 63 6f 6e 74 65 6e 74 2d 74 79 70 65 3b 68 6f 73 74 3b 78 2d 61 6d 7a 2d 63 6f 70 79 2d 73 6f 75 72 63 65 3b 78 2d 61 6d 7a 2d 64 61 74 65 3b 78 2d 72 65 71 75 65 73 74 2d 73 74 79 6c 65 0a 55 4e 53 49 47 4e 45 44 2d 50 41 59 4c 4f 41 44</CanonicalRequestBytes><RequestId>7BB361613A17B52F</RequestId><HostId>pbI8KAI6dFVy/Dd3vH11bsjT1bpnNB4CUIyKN9gOhUO9D2hOJql0siIllVHfYv4C71tXpgfSoNI=</HostId></Error>
```

## Purpose

What does this PR do?

## Background Context

x-amz-copy-source | The name of the source bucket and key name of the source object, separated                                        by a slash (/).                                                                                                               Type: String                                                                          Default: None                                                                          Constraints:                                                                           This string must be URL-encoded. Additionally, the source bucket must be                                        valid and you must have READ access to the valid source object.                                                                                                                If the source object is archived in Amazon S3 Glacier (the storage class of the object                                        is GLACIER), you must first restore a temporary copy using the POST Object restore.                                        Otherwise, Amazon S3 returns the 403 ObjectNotInActiveTierError error                                        response.
-- | --

> Take care to CEPH https://tracker.ceph.com/issues/22121