### PR TITLE
fix groupid in documentation

### DIFF
--- a/docs/play/integration.md
+++ b/docs/play/integration.md
@@ -9,12 +9,12 @@ The latest version of this plugin is for Play 2.6+, and can be enabled by adding
 ```ocaml
 // only for Play 2.6.x
 libraryDependencies ++= Seq(
-  "com.zengularity.benji" %% "benji-play" % "{{site.latest_release}}-play26"
+  "com.zengularity" %% "benji-play" % "{{site.latest_release}}-play26"
 )
 
 // only for Play 2.7.x
 libraryDependencies ++= Seq(
-  "com.zengularity.benji" %% "benji-play" % "{{site.latest_release}}-play27"
+  "com.zengularity" %% "benji-play" % "{{site.latest_release}}-play27"
 )
 ```
 
@@ -24,7 +24,7 @@ Then it's also required to enable the wanted backend, e.g. for S3:
 val benjiVer = {{site.latest_release}}
 
 libraryDependencies ++= Seq("play", "s3").map { mod =>
-  "com.zengularity.benji" %% s"benji-${mod}" % benjiVer,
+  "com.zengularity" %% s"benji-${mod}" % benjiVer,
 }
 ```
 


### PR DESCRIPTION

# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](../CONTRIBUTING.md)?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes

No open issue

## Purpose

Sbt could not download the play integration library because the groupid in the documentation was wrong (`com.zengularity.benji` instead of `com.zengularity`)
