### PR TITLE
Fix: S3 V4 signature with slash

### DIFF
--- a/s3/src/main/scala/WSRequestBuilder.scala
+++ b/s3/src/main/scala/WSRequestBuilder.scala
@@ -73,9 +73,6 @@ private[s3] object WSRequestBuilder {
       case ',' =>
         url.append("%2C")
 
-      case '/' =>
-        url.append("%2F")
-
       case ':' =>
         url.append("%3A")
 

--- a/s3/src/test/scala/S3Spec.scala
+++ b/s3/src/test/scala/S3Spec.scala
@@ -92,8 +92,15 @@ trait S3Spec extends BenjiMatchers { _: org.specs2.mutable.Specification =>
       val body = List.fill(100)("hello").mkString(" ").getBytes
       val upload = Source.single(body).runWith(put)
 
-      upload must beDone.await(2, 5.seconds)
-      file.delete() must beTypedEqualTo({}).await(1, 5.seconds)
+      {
+        upload must beDone.await(2, 5.seconds)
+      } and {
+        file must existsIn(bucket, 10, 5.seconds)
+      } and {
+        file.delete() must beTypedEqualTo({}).await(1, 5.seconds)
+      } and {
+        file must notExistsIn(bucket, 10, 5.seconds)
+      }
     }
   }
 }

--- a/s3/src/test/scala/SignatureCalculatorV4Spec.scala
+++ b/s3/src/test/scala/SignatureCalculatorV4Spec.scala
@@ -43,7 +43,7 @@ class SignatureCalculatorV4Spec extends org.specs2.mutable.Specification {
       val req = new RequestBuilder().
         setUrl(s"http://my-bucket.s3.amazonaws.com/${encodedName}").build()
 
-      calculator.canonicalUri(req) must_=== "/foo%20%21%23%24%26%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D%20%C3%A9toile"
+      calculator.canonicalUri(req) must_=== "/foo%20%21%23%24%26%26%27%28%29%2A%2B%2C/%3A%3B%3D%3F%40%5B%5D%20%C3%A9toile"
     }
 
     "compute canonical empty URI" in {


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](../CONTRIBUTING.md)?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #133

## Purpose

Remove slash uri-encoding

## References

- https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html#canonical-request
- https://docs.aws.amazon.com/AmazonS3/latest/user-guide/using-folders.html

## Note

Not sure if added test where at the right place
