### PR TITLE
Also sign the `x-amz-content-sha256` header

### DIFF
--- a/s3/src/test/scala/SignatureCalculatorV4Spec.scala
+++ b/s3/src/test/scala/SignatureCalculatorV4Spec.scala
@@ -60,7 +60,7 @@ class SignatureCalculatorV4Spec extends org.specs2.mutable.Specification {
 
     "compute canonical headers" >> {
       "for request #1" in {
-        calculator.canonicalHeaders(req1, "20150830T123600Z") must_=== ("content-type:application/x-www-form-urlencoded; charset=utf-8\nhost:my-bucket.s3.amazonaws.com\nmy-header1:a b c\nmy-header2:\"a b c\"\nx-amz-date:20150830T123600Z\n" -> "content-type;host;my-header1;my-header2;x-amz-date")
+        calculator.canonicalHeaders(req1, "20150830T123600Z", "UNSIGNED-PAYLOAD") must_=== ("content-type:application/x-www-form-urlencoded; charset=utf-8\nhost:my-bucket.s3.amazonaws.com\nmy-header1:a b c\nmy-header2:\"a b c\"\nx-amz-content-sha256:UNSIGNED-PAYLOAD\nx-amz-date:20150830T123600Z\n" -> "content-type;host;my-header1;my-header2;x-amz-content-sha256;x-amz-date")
       }
 
       "with request style header" in {
@@ -72,12 +72,13 @@ class SignatureCalculatorV4Spec extends org.specs2.mutable.Specification {
           addHeader("x-amz-date", "20180329T203920Z").
           build()
 
-        calculator.canonicalHeaders(req, "20180329T203920Z") must_=== (
+        calculator.canonicalHeaders(req, "20180329T203920Z", "UNSIGNED-PAYLOAD") must_=== (
           """content-type:text/plain; charset=UTF-8
 host:my-bucket.s3.amazonaws.com
+x-amz-content-sha256:UNSIGNED-PAYLOAD
 x-amz-date:20180329T203920Z
 x-request-style:virtualhost
-""" -> "content-type;host;x-amz-date;x-request-style")
+""" -> "content-type;host;x-amz-content-sha256;x-amz-date;x-request-style")
 
       }
     }
@@ -96,7 +97,7 @@ x-request-style:virtualhost
 
       calculator.canonicalRequest(
         req3, "20150830T123600Z", "UNSIGNED-PAYLOAD") must beTypedEqualTo(
-        canonicalRequest1 -> "content-type;host;x-amz-date")
+        canonicalRequest1 -> "content-type;host;x-amz-content-sha256;x-amz-date")
     }
   }
 
@@ -114,7 +115,7 @@ x-request-style:virtualhost
         credentialScope) must_=== """AWS4-HMAC-SHA256
 20150830T123600Z
 20150830/us-east-1/iam/aws4_request
-2714b15fec5795e21b0fa0c48f6944f639224b42fd8e71d16f57ed58265f9c7d"""
+b243baaf68a974acdc3a4273f5cdab2f6118c28b0f54623242c108eb45309a35"""
     }
   }
 
@@ -149,9 +150,10 @@ x-request-style:virtualhost
 Action=ListUsers&Version=2010-05-08
 content-type:application/x-www-form-urlencoded; charset=utf-8
 host:iam.amazonaws.com
+x-amz-content-sha256:UNSIGNED-PAYLOAD
 x-amz-date:20150830T123600Z
 
-content-type;host;x-amz-date
+content-type;host;x-amz-content-sha256;x-amz-date
 UNSIGNED-PAYLOAD"""
 
   private val credentialScope = "20150830/us-east-1/iam/aws4_request"


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read through the [contributor guidelines](https://github.com/zengularity/benji/blob/master/CONTRIBUTING.md#contributor-guidelines)?
* [ ] N/A Have you updated the documentation?
* [X] Have you ~added~ updated tests for any changed functionality?

## Purpose

Add `x-amz-content-sha256` to the list of signed headers in `SignatureCalculatorV4`.

Yandex Cloud offers [S3 compatible buckets](https://cloud.yandex.com/en/docs/storage/). Unfortunately when trying to access them using `benji` we get a 403 error back with the message (reformatted for better readability):
```<?xmlversion="1.0" encoding="UTF-8"?>
<Error>
  <Code>AccessDenied</Code>
  <Message>There were headers present in the request which were not signed</Message>
  <Resource>resource_path</Resource>
  <RequestId>something</RequestId>
  <HeadersNotSigned>x-amz-content-sha256</HeadersNotSigned>
</Error>
```

Accessing a S3 bucket on AWS with the same code works, so this may indicate Yandex validation is a bit stricter.

Adding the `x-amz-content-sha256` to the list of signed headers makes the issue go away.

## Background Context

This PR tries to minimize changes to the code since I'm not familiar with its design. There is already a special handling of the `x-amz-date` header so this PR reuses the same logic. Test expectations have been updated to reflect the changes.